### PR TITLE
Adiciona media queries em header.css para tornar a seção responsiva

### DIFF
--- a/css/header.css
+++ b/css/header.css
@@ -3,10 +3,6 @@
     flex-direction:column ;
 }
 
-.cabecalho-fale-conosco {
-    align-self: flex-end;
-}
-
 .cabecalho-container {
     display: flex;
     flex-direction:column ;
@@ -64,4 +60,56 @@
 .cabecalho-nav a:hover {
     color: #1F336A;
     text-shadow: 0px 0px 3px rgb(31, 51, 106, 30%);
+}
+
+@media only screen and (min-width:768px) and (max-width:1023px){
+    
+    .cabecalho-principal {
+        flex-direction: column;
+    } 
+
+    .cabecalho-principal p {
+        font-size: 0px;
+    } 
+
+}
+
+@media only screen and (max-width: 767px){
+
+    .cabecalho-container{
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-around;
+        height: auto;
+        padding: 25px 0;
+    }
+
+    .cabecalho-principal {
+        flex-direction: column;
+    } 
+
+    .cabecalho-principal p {
+        font-size: 0px;
+    } 
+
+    .cabecalho-logo {
+        height: 4rem;
+    }
+
+    .cabecalho-nav {
+        width: 50%;
+        margin: 0;
+        padding:0;
+        width: 100%;
+        border:none;
+        flex-direction: column;
+        width: 25%;
+    }
+
+    .cabecalho-nav a {
+        text-align: center;
+        font-size: .8rem;
+        text-size-adjust: auto;
+        margin: .25em 0;
+    }
 }

--- a/css/inscrever.css
+++ b/css/inscrever.css
@@ -68,7 +68,7 @@
     display: flex;
     flex-direction:row; 
     height: 109px;
-    width: 300px;
+    width: 30%;
     background-color: #F4BC1D;
     align-items:center;
     justify-content:space-between; 

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
         <section class="cabecalho">
             <div class="cabecalho-container">
                 <div class="cabecalho-principal">
-                    <img class="cabecalho-logo" src="img/logo.png" alt="">
+                    <img class="cabecalho-logo" src="img/logo.png" alt="Logo da agência Zen">
                     <p>Viajar sem estresse?<br>Você pode também!</p>
                 </div>
                 <nav class="cabecalho-nav">


### PR DESCRIPTION
## Modificações propostas

- Foram adicionadas duas `media queries` no arquivo `header.css`. Uma que trata quando o display do usuário é menor que 768px (Mobile) e outra que trata quando o display do usuário está entre 768px e 1023px (Tablet).

- Foi adicionada a descrição `alt` na imagem do logo da página.

- Foram revisados os códigos dos arquivos `header.css` e `index.html` para tratar de manter o padrão de escrita das classes com o definido pelo grupo (nome-minúsculo-separado-por-traço)

- Foram também revisadas as imagens utilizadas na seção header para que estas obedeçam os mesmos padrões de nomenclatura das classes css.

 